### PR TITLE
Fix select element background on iOS 15

### DIFF
--- a/packages/css/src/components/form-elements.css
+++ b/packages/css/src/components/form-elements.css
@@ -4,7 +4,7 @@
     & input,
     & select,
     & textarea {
-        @apply block border text-gray-700 border-bluegray-300 px-8 py-12 rounded-4 w-full;
+        @apply block border bg-white text-gray-700 border-bluegray-300 px-8 py-12 rounded-4 w-full;
 
         &:hover {
             @apply border-gray-500;


### PR DESCRIPTION
As mentioned in #fabric-private - we need to explicitly set this for iOS 15 or it turns the background gray