### PR TITLE
Add additional transition durations

### DIFF
--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -40,6 +40,10 @@ module.exports = {
         strokeWidth: false,
     },
     theme: {
+        extend: {
+          '0': '0ms',
+          '1': '1ms'
+        },
         aspectRatio: {
           1: '1',
           2: '2',


### PR DESCRIPTION
Both of these are used in Modal for fixing a UI edgecase. Might as well make them globally available instead of scoped specifically to Modal.