### PR TITLE
docs: direct users to the setup guide on the design site

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,54 +29,9 @@
 
             <h2>Getting started</h2>
 
-            <h3>CDN (recommended)</h3>
-
             <p>
-              The recommended way to use Fabric is by loading it from our
-              <a href="https://eik.dev/">Eik</a>
-              CDN.
-            </p>
-
-            <p>
-              Since Eik supports
-              <a href="https://eik.dev/docs/overview_concepts#aliasing">aliasing by major versions</a>
-              you can load Fabric by specifing only the major version you're relying upon. This is great,
-              because it allows us to efficiently utilize the browser's cache as the user navigates FINN, and
-              it ensures you're always using the latest minor.patch version.
-            </p>
-
-            <p>In HTML:</p>
-            <syntax-highlight>
-              &lt;link href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css" rel="stylesheet" />
-            </syntax-highlight>
-
-            <h3>npm (alternative)</h3>
-
-            <p>
-              Even though we recommend using Fabric through the Eik CDN, you can also install it as an
-              <a href="https://www.npmjs.com/">npm</a>
-              package:
-            </p>
-
-            <syntax-highlight>$ npm install @fabric-ds/css</syntax-highlight>
-
-            <p>
-              The
-              <code>package.json</code>
-              contains the path to the minified CSS under the
-              <code>style</code>
-              key.
-            </p>
-
-            <h2>Usage with Podium</h2>
-            <p>
-              If you are developing with
-              <a href="https://podium-lib.io/">Podium</a>
-              , Fabric's CSS should only by included by the
-              <a href="https://podium-lib.io/docs/layout/getting_started">layout server</a>
-              , not the individual
-              <a href="https://podium-lib.io/docs/podlet/getting_started">podlets</a>
-              . This prevents accidentally including several versions of Fabric on the same page.
+              You can use our getting started guide to install Fabric in your project. 
+              Head on over to the <a href="https://www.fabric-ds.io/guide-setup">setup guide</a> to begin.
             </p>
           </div>
           <div>


### PR DESCRIPTION
Point users to the getting setup guide on the design site

https://www.fabric-ds.io/guide-setup