### PR TITLE
fix: add tailwind and aspect ratio plugin as deps

### DIFF
--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.24",
   "description": "Fabric's Tailwind configuration",
   "main": "tailwind.config.js",
+  "dependencies": {
+    "@tailwindcss/aspect-ratio": "^0.3.0",
+    "tailwindcss": "^2.2.19"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:fabric-ds/css.git"


### PR DESCRIPTION
We are missing dependencies which means that our config fails on tailwind play. See: https://github.com/tailwindlabs/play.tailwindcss.com/issues/23#issuecomment-954761912

We could add them as peer deps but thinking about it, I'm not sure we'd want/need to since our approach to TW is to produce a global bundle. If we include them as deps rather than peer deps then it should mean there's less for users to install when they are setting up code completion support for their ides. I think... all they'd need to do is install this package and not need to install anything else.