### PR TITLE
Align font-weight to 'normal' (400)

### DIFF
--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -145,7 +145,7 @@ module.exports = {
             34: ['34px', '41px'],
         },
         fontWeight: {
-            normal: 300,
+            normal: 400,
             bold: 700,
         },
         // Effects


### PR DESCRIPTION
In our headings plugin, we set `font-weight: normal !important` which results in `font-weight: 400` as a rule. I think we had set 300 because Troika used this, but it'd be good to align one way or another, and 400 seems more correct.