### PR TITLE
fix: try to always HW-accelerate the chevron animation

### DIFF
--- a/src/utils/component-classes/index.js
+++ b/src/utils/component-classes/index.js
@@ -168,7 +168,7 @@ export const expandable = {
     expandableInfo: 'bg-aqua-50',
     expandableBox: 'py-0 px-0 ' + box.box,
     expandableBleed: box.bleed,
-    chevron: 'inline-block align-middle transform transition-transform',
+    chevron: 'inline-block align-middle transform transition-transform transition-gpu',
     chevronNonBox: 'relative left-8',
     chevronBox: 'f-expandable-chevron absolute right-16',
     chevronExpanded: '-rotate-180',


### PR DESCRIPTION
UXUI has noted that the chevron feels a bit different between animated and non-animated versions.

This is primarily due to a trick of the eye, but possibly helped by the fact that the animation _might_ be GPU accelerated since our expansion-animation is (or tries to be).

This is a quickfix and is basically the best we can do!