### PR TITLE
fix: Doc change

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ npm run dev
 
 Changes to to either the CSS, Tailwind configuration or the HTML files should hot reload.
 
+
+We use [commitizen](https://github.com/commitizen/cz-cli) to ensure coherent commit message structure, used by [semantic release](#releases) to generate change logs and handle versioning.
+
+```
+npm install -g commitizen
+```
+
+When installed, you should be able to type `cz` or `git cz` in your terminal to commit your changes (replacing
+`git commit`).
+
+[![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
+
+
 ## Releases
 
 This project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automate package
@@ -46,14 +59,4 @@ changes are ready for pull request, this should be opened against the `next` bra
 
 [Read more in-depth about Fabric Releases here](https://github.com/fabric-ds/issues/blob/779d59723993c13d62374516259602d967da56ca/rfcs/0004-releases.md).
 
-Please note that the version published will depend on your commit message structure. We use
-[commitizen](https://github.com/commitizen/cz-cli) to help follow this structure:
-
-```
-npm install -g commitizen
-```
-
-When installed, you should be able to type `cz` or `git cz` in your terminal to commit your changes (replacing
-`git commit`).
-
-[![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
+Please note that the version published will depend on your commit message structure. Make sure to use commitizen (see [Development section](#development)).


### PR DESCRIPTION
Move the Commitizen documentation from releaase to Development section. 

(it is a fix: to trigger a new release)